### PR TITLE
moveCursor() e altre piccole funzioni

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+
+# Matches multiple files with brace expansion notation
+# Set default charset
+[*.{js,jsx,html,sass,scss,css}]
+charset = utf-8
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -11,8 +11,8 @@ insert_final_newline = true
 
 # Matches multiple files with brace expansion notation
 # Set default charset
-[*.{js,jsx,html,sass,scss,css}]
+[*.{js,jsx,html,sass,scss,css,cpp,h}]
 charset = utf-8
 indent_style = space
-indent_size = 2
+indent_size = 4
 trim_trailing_whitespace = true

--- a/PCF8574_HD44780_I2C/Examples/GetCursor/GetCursor.ino
+++ b/PCF8574_HD44780_I2C/Examples/GetCursor/GetCursor.ino
@@ -1,8 +1,11 @@
 #include <Wire.h>
 #include <PCF8574_HD44780_I2C.h>
 
+#define COLS 20
+#define ROWS 4
+
 // Address 0x27, 16 chars, 2 line display
-PCF8574_HD44780_I2C lcd(0x27,20,4);
+PCF8574_HD44780_I2C lcd(0x27, COLS, ROWS);
 
 uint8_t col, row;
 
@@ -11,39 +14,30 @@ void setup()
   Serial.begin(115200);
   lcd.init();           // LCD Initialization
   lcd.backlight();      // Backlight ON
-
   lcd.clear();          // Clear the display
-  lcd.print("Hello, World...");
-  lcd.getCursor(col, row);
-  Serial.print("Row: ");
-  Serial.print(row);
-  Serial.print("; Col: ");
-  Serial.println(col);
+
+  lcd.print("Hello World!");
 
   lcd.setCursor(0, 1);
-  lcd.print("Hello, World!");
+  lcd.print("The second row...");
   lcd.getCursor(col, row);
   Serial.print("Row: ");
   Serial.print(row);
   Serial.print("; Col: ");
   Serial.println(col);
 
-  lcd.setCursor(0, 2);
-  lcd.print("Hello Worldddd");
-  lcd.getCursor(col, row);
-  Serial.print("Row: ");
-  Serial.print(row);
-  Serial.print("; Col: ");
-  Serial.println(col);
+  lcd.blink();                                                // Show where cursor is
+  delay(2000);
+  lcd.moveCursor(PCF8574_HD44780_I2C::LCD_UP);                // Move one row UP
+  delay(2000);
+  lcd.moveCursor(PCF8574_HD44780_I2C::LCD_LEFT, lcd.col());   // Move back to the beginning of row
 
-  lcd.setCursor(0, 3);
-  lcd.print("Hello Bro'");
-  lcd.getCursor(col, row);
-  Serial.print("Row: ");
-  Serial.print(row);
-  Serial.print("; Col: ");
-  Serial.println(col);
+  delay(2000);
+  lcd.noBlink();
 
+  char strBuf[COLS +1];
+  lcd.getString(strBuf, COLS-1);     // Note: getString() move also the cursor
+  Serial.println(strBuf);
 }
 
 void loop()

--- a/PCF8574_HD44780_I2C/PCF8574_HD44780_I2C.cpp
+++ b/PCF8574_HD44780_I2C/PCF8574_HD44780_I2C.cpp
@@ -219,12 +219,12 @@ void PCF8574_HD44780_I2C::backlight(void) {
 
 // Get status byte (busy flag & DDRAM address)
 int PCF8574_HD44780_I2C::status() {
-  return read(0);
+    return read(0);
 }
 
 // Get the character at actual cursor position
 char PCF8574_HD44780_I2C::getChar() {
-  return (char)read(1);
+    return (char)read(1);
 }
 
 // Get fixed size text from actual cursor position
@@ -242,19 +242,19 @@ void PCF8574_HD44780_I2C::getCursor(uint8_t &col, uint8_t &row) {
   	uint8_t baseAdr = addr - ((addr&0x3F)%_cols);
 	switch (baseAdr) {
 		case 0x0:
-		row = 0;
-		break;
+		    row = 0;
+		    break;
 		case 0x40:
-		row = 1;
-		break;
+		    row = 1;
+		    break;
 		case 0x14:
-		row = 2;
-		break;
+		    row = 2;
+		    break;
 		case 0x54:
-		row = 3;
-		break;
+		    row = 3;
+		    break;
 		default:
-		break;
+		    break;
 	}
 		col = addr - baseAdr;
 }
@@ -275,6 +275,8 @@ void PCF8574_HD44780_I2C::moveCursor(uint8_t dir, uint8_t step) {
 		case LCD_RIGHT:
 			setCursor((_col + step)%_cols, _row);
 			break;
+        default:
+		    break;
 	}
 }
 
@@ -290,9 +292,7 @@ inline size_t PCF8574_HD44780_I2C::write(uint8_t value) {
 }
 
 
-
 /************ low level data pushing commands **********/
-
 
 // read either command or data
 int PCF8574_HD44780_I2C::read(uint8_t mode) {

--- a/PCF8574_HD44780_I2C/PCF8574_HD44780_I2C.cpp
+++ b/PCF8574_HD44780_I2C/PCF8574_HD44780_I2C.cpp
@@ -251,7 +251,7 @@ void PCF8574_HD44780_I2C::getCursor(uint8_t &col, uint8_t &row) {
 }
 
 void PCF8574_HD44780_I2C::moveCursor(uint8_t dir, uint8_t step) {
-	uint8_t _col, _row = 0;
+	uint8_t _col = 0, _row = 0;
 	getCursor(_col, _row);
 	switch (dir) {
 	case LCD_UP:
@@ -269,6 +269,20 @@ void PCF8574_HD44780_I2C::moveCursor(uint8_t dir, uint8_t step) {
 	}
 }
 
+// Get current column position
+uint8_t PCF8574_HD44780_I2C::col(){
+    uint8_t _col = 0, _row = 0;
+	getCursor(_col, _row);
+    return _col;
+}
+
+// Get current row position
+uint8_t PCF8574_HD44780_I2C::row(){
+    uint8_t _col = 0, _row = 0;
+	getCursor(_col, _row);
+    return _row;
+}
+
 /*********** mid level commands, for sending data/cmds */
 
 inline void PCF8574_HD44780_I2C::command(uint8_t value) {
@@ -284,7 +298,7 @@ inline size_t PCF8574_HD44780_I2C::write(uint8_t value) {
 
 // read either command or data
 int PCF8574_HD44780_I2C::read(uint8_t mode) {
-	uint8_t gpio, data, iodata = 0;
+	uint8_t gpio = 0, data = 0, iodata = 0;
 
 	delayMicroseconds(45); // ensure that previous LCD instruction finished.
 	// Put all the expander LCD data pins into input mode.

--- a/PCF8574_HD44780_I2C/PCF8574_HD44780_I2C.cpp
+++ b/PCF8574_HD44780_I2C/PCF8574_HD44780_I2C.cpp
@@ -42,13 +42,15 @@ void PCF8574_HD44780_I2C::init() {
 	init_priv();
 }
 
-void PCF8574_HD44780_I2C::init_priv() {
+void PCF8574_HD44780_I2C::init_priv() 
+{
 	Wire.begin();
 	_displayfunction = LCD_4BITMODE | LCD_1LINE | LCD_5x8DOTS;
 	begin(_cols, _rows);
 }
 
-void PCF8574_HD44780_I2C::begin(uint8_t cols, uint8_t lines, uint8_t dotsize) {
+void PCF8574_HD44780_I2C::begin(uint8_t cols, uint8_t lines, uint8_t dotsize) 
+{
 	if (lines > 1) {
 		_displayfunction |= LCD_2LINE;
 	}
@@ -108,8 +110,8 @@ void PCF8574_HD44780_I2C::begin(uint8_t cols, uint8_t lines, uint8_t dotsize) {
 
 /********** high level commands, for the user! */
 void PCF8574_HD44780_I2C::clear() {
-	command(LCD_CLEARDISPLAY);   // clear display, set cursor position to zero
-	delayMicroseconds(2000);	 // this command takes a long time!
+	command(LCD_CLEARDISPLAY); // clear display, set cursor position to zero
+	delayMicroseconds(2000);   // this command takes a long time!
 }
 
 void PCF8574_HD44780_I2C::home() {
@@ -119,7 +121,7 @@ void PCF8574_HD44780_I2C::home() {
 
 void PCF8574_HD44780_I2C::setCursor(uint8_t col, uint8_t row) {
 	int row_offsets[] = {0x00, 0x40, 0x14, 0x54}; // LCD Addressing
-	if (row > _numlines) 	{
+	if (row > _numlines) {
 		row = _numlines - 1; // we count rows starting w/0
 	}
 	command(LCD_SETDDRAMADDR | (col + row_offsets[row]));

--- a/PCF8574_HD44780_I2C/PCF8574_HD44780_I2C.cpp
+++ b/PCF8574_HD44780_I2C/PCF8574_HD44780_I2C.cpp
@@ -216,6 +216,26 @@ void PCF8574_HD44780_I2C::backlight(void) {
 	expanderWrite(0);
 }
 
+
+// Get status byte (busy flag & DDRAM address)
+int PCF8574_HD44780_I2C::status() {
+  return read(0);
+}
+
+// Get the character at actual cursor position
+char PCF8574_HD44780_I2C::getChar() {
+  return (char)read(1);
+}
+
+// Get fixed size text from actual cursor position
+void PCF8574_HD44780_I2C::getString(char* buffer, size_t len) {
+	uint8_t i = 0;
+	for(i=0; i<min(len, _cols); i++){
+		buffer[i] = getChar();
+	}
+	buffer[i] = '\0';
+}
+
 // Get the current cursor position
 void PCF8574_HD44780_I2C::getCursor(uint8_t &col, uint8_t &row) {
 	uint8_t addr = status();
@@ -239,6 +259,24 @@ void PCF8574_HD44780_I2C::getCursor(uint8_t &col, uint8_t &row) {
 		col = addr - baseAdr;
 }
 
+void PCF8574_HD44780_I2C::moveCursor(uint8_t dir, uint8_t step) {
+	uint8_t _col, _row = 0;
+	getCursor(_col, _row);
+	switch (dir) {
+		case LCD_UP:
+			setCursor(_col, (_row - step)%_rows);
+			break;
+		case LCD_DOWN:
+		  setCursor(_col, (_row + step)%_rows);
+			break;
+		case LCD_LEFT:
+			setCursor((_col - step)%_cols, _row);
+			break;
+		case LCD_RIGHT:
+			setCursor((_col + step)%_cols, _row);
+			break;
+	}
+}
 
 /*********** mid level commands, for sending data/cmds */
 
@@ -312,7 +350,6 @@ void PCF8574_HD44780_I2C::expanderWrite(uint8_t _data){
 	Wire.write((int)(_data) | _backlightval);
 	Wire.endTransmission();
 }
-
 
 
 void PCF8574_HD44780_I2C::pulseEnable(uint8_t _data){

--- a/PCF8574_HD44780_I2C/PCF8574_HD44780_I2C.cpp
+++ b/PCF8574_HD44780_I2C/PCF8574_HD44780_I2C.cpp
@@ -404,7 +404,6 @@ void PCF8574_HD44780_I2C::printstr(const char c[]) {
 void PCF8574_HD44780_I2C::off() {}
 void PCF8574_HD44780_I2C::on() {}
 void PCF8574_HD44780_I2C::setDelay(int cmdDelay, int charDelay) {}
-
 uint8_t PCF8574_HD44780_I2C::keypad() { return 0; }
 uint8_t PCF8574_HD44780_I2C::init_bargraph(uint8_t graphtype) { return 0; }
 void PCF8574_HD44780_I2C::draw_horizontal_graph(uint8_t row, uint8_t column, uint8_t len, uint8_t pixel_col_end) {}

--- a/PCF8574_HD44780_I2C/PCF8574_HD44780_I2C.cpp
+++ b/PCF8574_HD44780_I2C/PCF8574_HD44780_I2C.cpp
@@ -7,12 +7,10 @@ based on code from:
 - Mario H.
 **********************************/
 
-
 #include "PCF8574_HD44780_I2C.h"
 #include <inttypes.h>
 #include "Wire.h"
 #include "Arduino.h"
-
 
 // When the display powers up, it is configured as follows:
 //
@@ -33,20 +31,18 @@ based on code from:
 // can't assume that its in that state when a sketch starts (and the
 // LiquidCrystal constructor is called).
 
-PCF8574_HD44780_I2C::PCF8574_HD44780_I2C(uint8_t lcd_Addr,uint8_t lcd_cols,uint8_t lcd_rows)
-{
-  _Addr = lcd_Addr;
-  _cols = lcd_cols;
-  _rows = lcd_rows;
-  _backlightval = LCD_NOBACKLIGHT;
+PCF8574_HD44780_I2C::PCF8574_HD44780_I2C(uint8_t lcd_Addr, uint8_t lcd_cols, uint8_t lcd_rows) {
+	_Addr = lcd_Addr;
+	_cols = lcd_cols;
+	_rows = lcd_rows;
+	_backlightval = LCD_NOBACKLIGHT;
 }
 
-void PCF8574_HD44780_I2C::init(){
+void PCF8574_HD44780_I2C::init() {
 	init_priv();
 }
 
-void PCF8574_HD44780_I2C::init_priv()
-{
+void PCF8574_HD44780_I2C::init_priv() {
 	Wire.begin();
 	_displayfunction = LCD_4BITMODE | LCD_1LINE | LCD_5x8DOTS;
 	begin(_cols, _rows);
@@ -59,7 +55,7 @@ void PCF8574_HD44780_I2C::begin(uint8_t cols, uint8_t lines, uint8_t dotsize) {
 	_numlines = lines;
 
 	// for some 1 line displays you can select a 10 pixel high font
-	if ((dotsize != 0) && (lines == 1)) {
+	if ((dotsize != 0) && (lines == 1))	{
 		_displayfunction |= LCD_5x10DOTS;
 	}
 
@@ -73,7 +69,7 @@ void PCF8574_HD44780_I2C::begin(uint8_t cols, uint8_t lines, uint8_t dotsize) {
 	//expanderWrite(_backlightval);	// reset expanderand turn backlight off (Bit 8 =1) - _backlightval = LCD_NOBACKLIGHT;
 	//delay(1000);
 
-  	// put the LCD into 4 bit mode
+	// put the LCD into 4 bit mode
 	// this is according to the hitachi HD44780 datasheet
 	// figure 24, pg 46
 
@@ -90,7 +86,6 @@ void PCF8574_HD44780_I2C::begin(uint8_t cols, uint8_t lines, uint8_t dotsize) {
 
 	// Set interface to be 4 bits long
 	write4bits(_BV(P5));
-
 
 	// set # lines, font size, etc.
 	command(LCD_FUNCTIONSET | _displayfunction);
@@ -109,26 +104,23 @@ void PCF8574_HD44780_I2C::begin(uint8_t cols, uint8_t lines, uint8_t dotsize) {
 	command(LCD_ENTRYMODESET | _displaymode);
 
 	home();
-
 }
-
-
 
 /********** high level commands, for the user! */
-void PCF8574_HD44780_I2C::clear(){
-	command(LCD_CLEARDISPLAY);// clear display, set cursor position to zero
-	delayMicroseconds(2000);  // this command takes a long time!
+void PCF8574_HD44780_I2C::clear() {
+	command(LCD_CLEARDISPLAY);   // clear display, set cursor position to zero
+	delayMicroseconds(2000);	 // this command takes a long time!
 }
 
-void PCF8574_HD44780_I2C::home(){
-	command(LCD_RETURNHOME);  // set cursor position to zero
-	delayMicroseconds(2000);  // this command takes a long time!
+void PCF8574_HD44780_I2C::home() {
+	command(LCD_RETURNHOME); // set cursor position to zero
+	delayMicroseconds(2000); // this command takes a long time!
 }
 
-void PCF8574_HD44780_I2C::setCursor(uint8_t col, uint8_t row){
-	int row_offsets[] = { 0x00, 0x40, 0x14, 0x54 };				// LCD Addressing
-	if ( row > _numlines ) {
-		row = _numlines-1;    // we count rows starting w/0
+void PCF8574_HD44780_I2C::setCursor(uint8_t col, uint8_t row) {
+	int row_offsets[] = {0x00, 0x40, 0x14, 0x54}; // LCD Addressing
+	if (row > _numlines) 	{
+		row = _numlines - 1; // we count rows starting w/0
 	}
 	command(LCD_SETDDRAMADDR | (col + row_offsets[row]));
 }
@@ -200,37 +192,36 @@ void PCF8574_HD44780_I2C::noAutoscroll(void) {
 void PCF8574_HD44780_I2C::createChar(uint8_t location, uint8_t charmap[]) {
 	location &= 0x7; // we only have 8 locations 0-7
 	command(LCD_SETCGRAMADDR | (location << 3));
-	for (int i=0; i<8; i++) {
+	for (int i = 0; i < 8; i++) {
 		write(charmap[i]);
 	}
 }
 
 // Turn the (optional) backlight off/on
 void PCF8574_HD44780_I2C::noBacklight(void) {
-	_backlightval=LCD_NOBACKLIGHT;
+	_backlightval = LCD_NOBACKLIGHT;
 	expanderWrite(0);
 }
 
 void PCF8574_HD44780_I2C::backlight(void) {
-	_backlightval=LCD_BACKLIGHT;
+	_backlightval = LCD_BACKLIGHT;
 	expanderWrite(0);
 }
 
-
 // Get status byte (busy flag & DDRAM address)
 int PCF8574_HD44780_I2C::status() {
-    return read(0);
+	return read(0);
 }
 
 // Get the character at actual cursor position
 char PCF8574_HD44780_I2C::getChar() {
-    return (char)read(1);
+	return (char)read(1);
 }
 
 // Get fixed size text from actual cursor position
-void PCF8574_HD44780_I2C::getString(char* buffer, size_t len) {
+void PCF8574_HD44780_I2C::getString(char *buffer, size_t len) {
 	uint8_t i = 0;
-	for(i=0; i<min(len, _cols); i++){
+	for (i = 0; i < min(len, _cols); i++) {
 		buffer[i] = getChar();
 	}
 	buffer[i] = '\0';
@@ -239,44 +230,42 @@ void PCF8574_HD44780_I2C::getString(char* buffer, size_t len) {
 // Get the current cursor position
 void PCF8574_HD44780_I2C::getCursor(uint8_t &col, uint8_t &row) {
 	uint8_t addr = status();
-  	uint8_t baseAdr = addr - ((addr&0x3F)%_cols);
+	uint8_t baseAdr = addr - ((addr & 0x3F) % _cols);
 	switch (baseAdr) {
-		case 0x0:
-		    row = 0;
-		    break;
-		case 0x40:
-		    row = 1;
-		    break;
-		case 0x14:
-		    row = 2;
-		    break;
-		case 0x54:
-		    row = 3;
-		    break;
-		default:
-		    break;
+	case 0x0:
+		row = 0;
+		break;
+	case 0x40:
+		row = 1;
+		break;
+	case 0x14:
+		row = 2;
+		break;
+	case 0x54:
+		row = 3;
+		break;
+	default:
+		break;
 	}
-		col = addr - baseAdr;
+	col = addr - baseAdr;
 }
 
 void PCF8574_HD44780_I2C::moveCursor(uint8_t dir, uint8_t step) {
 	uint8_t _col, _row = 0;
 	getCursor(_col, _row);
 	switch (dir) {
-		case LCD_UP:
-			setCursor(_col, (_row - step)%_rows);
-			break;
-		case LCD_DOWN:
-		  setCursor(_col, (_row + step)%_rows);
-			break;
-		case LCD_LEFT:
-			setCursor((_col - step)%_cols, _row);
-			break;
-		case LCD_RIGHT:
-			setCursor((_col + step)%_cols, _row);
-			break;
-        default:
-		    break;
+	case LCD_UP:
+		setCursor(_col, (_row - step) % _rows);
+		break;
+	case LCD_DOWN:
+		setCursor(_col, (_row + step) % _rows);
+		break;
+	case LCD_LEFT:
+		setCursor((_col - step) % _cols, _row);
+		break;
+	case LCD_RIGHT:
+		setCursor((_col + step) % _cols, _row);
+		break;
 	}
 }
 
@@ -288,9 +277,8 @@ inline void PCF8574_HD44780_I2C::command(uint8_t value) {
 
 inline size_t PCF8574_HD44780_I2C::write(uint8_t value) {
 	send(value, Rs);
-	return 1;			// https://github.com/marcoschwartz/LiquidCrystal_I2C/pull/5
+	return 1; // https://github.com/marcoschwartz/LiquidCrystal_I2C/pull/5
 }
-
 
 /************ low level data pushing commands **********/
 
@@ -298,15 +286,15 @@ inline size_t PCF8574_HD44780_I2C::write(uint8_t value) {
 int PCF8574_HD44780_I2C::read(uint8_t mode) {
 	uint8_t gpio, data, iodata = 0;
 
-	delayMicroseconds(45);  // ensure that previous LCD instruction finished.
+	delayMicroseconds(45); // ensure that previous LCD instruction finished.
 	// Put all the expander LCD data pins into input mode.
 	// PCF8574 psuedo inputs use pullups so setting them to 1.
-	gpio |= _BV(P4)|_BV(P5)|_BV(P6)|_BV(P7);
+	gpio |= _BV(P4) | _BV(P5) | _BV(P6) | _BV(P7);
 	// Set RS based on type of read (data or status/cmd)
-	if(mode) {
-		gpio |= Rs;   // RS high to read data reg
+	if (mode) {
+		gpio |= Rs; // RS high to read data reg
 	}
-	gpio |= Rw; 	  // R/W high for reading
+	gpio |= Rw; // R/W high for reading
 	// P4-P7 are inputs, RS, R/W high, En LOW
 	expanderWrite(gpio);
 	// Raise En
@@ -319,25 +307,23 @@ int PCF8574_HD44780_I2C::read(uint8_t mode) {
 	expanderWrite(gpio);
 	// Raise E to read next nibble
 	expanderWrite(gpio | En);
-	 // Read upper nibble of the byte
+	// Read upper nibble of the byte
 	Wire.requestFrom((int)_Addr, 1);
 	iodata = Wire.read();
 	data |= (iodata >> 4 & 0b00001111);
 	// lower En after reading nibble
 	expanderWrite(gpio);
 	// Restore gpio as outputs
-    expanderWrite(0);
+	expanderWrite(0);
 	return data;
 }
 
-
-
 // write either command or data
 void PCF8574_HD44780_I2C::send(uint8_t value, uint8_t mode) {
-	uint8_t highnib=value & 0xF0;
-	uint8_t lownib=value << 4;
-	write4bits((highnib)|mode);
-	write4bits((lownib)|mode);
+	uint8_t highnib = value & 0xF0;
+	uint8_t lownib = value << 4;
+	write4bits((highnib) | mode);
+	write4bits((lownib) | mode);
 }
 
 void PCF8574_HD44780_I2C::write4bits(uint8_t value) {
@@ -345,67 +331,64 @@ void PCF8574_HD44780_I2C::write4bits(uint8_t value) {
 	pulseEnable(value);
 }
 
-void PCF8574_HD44780_I2C::expanderWrite(uint8_t _data){
+void PCF8574_HD44780_I2C::expanderWrite(uint8_t _data) {
 	Wire.beginTransmission(_Addr);
 	Wire.write((int)(_data) | _backlightval);
 	Wire.endTransmission();
 }
 
+void PCF8574_HD44780_I2C::pulseEnable(uint8_t _data) {
+	expanderWrite(_data | En); // En high
+	delayMicroseconds(1);	   // enable pulse must be >450ns
 
-void PCF8574_HD44780_I2C::pulseEnable(uint8_t _data){
-	expanderWrite(_data | En);	// En high
-	delayMicroseconds(1);		// enable pulse must be >450ns
-
-	expanderWrite(_data & ~En);	// En low
+	expanderWrite(_data & ~En); // En low
 	delayMicroseconds(50);		// commands need > 37us to settle
 }
 
-
 // Alias functions
 
-void PCF8574_HD44780_I2C::cursor_on(){
+void PCF8574_HD44780_I2C::cursor_on() {
 	cursor();
 }
 
-void PCF8574_HD44780_I2C::cursor_off(){
+void PCF8574_HD44780_I2C::cursor_off() {
 	noCursor();
 }
 
-void PCF8574_HD44780_I2C::blink_on(){
+void PCF8574_HD44780_I2C::blink_on() {
 	blink();
 }
 
-void PCF8574_HD44780_I2C::blink_off(){
+void PCF8574_HD44780_I2C::blink_off() {
 	noBlink();
 }
 
-void PCF8574_HD44780_I2C::load_custom_character(uint8_t char_num, uint8_t *rows){
-		createChar(char_num, rows);
+void PCF8574_HD44780_I2C::load_custom_character(uint8_t char_num, uint8_t *rows) {
+	createChar(char_num, rows);
 }
 
-void PCF8574_HD44780_I2C::setBacklight(uint8_t new_val){
-	if(new_val){
-		backlight();		// turn backlight on
-	}else{
-		noBacklight();		// turn backlight off
+void PCF8574_HD44780_I2C::setBacklight(uint8_t new_val) {
+	if (new_val) {
+		backlight();   // turn backlight on
+	}
+	else {
+		noBacklight(); // turn backlight off
 	}
 }
 
-void PCF8574_HD44780_I2C::printstr(const char c[]){
+void PCF8574_HD44780_I2C::printstr(const char c[]) {
 	//This function is not identical to the function used for "real" I2C displays
 	//it's here so the user sketch doesn't have to be changed
 	print(c);
 }
 
-
 // unsupported API functions
-void PCF8574_HD44780_I2C::off(){}
-void PCF8574_HD44780_I2C::on(){}
-void PCF8574_HD44780_I2C::setDelay (int cmdDelay,int charDelay) {}
+void PCF8574_HD44780_I2C::off() {}
+void PCF8574_HD44780_I2C::on() {}
+void PCF8574_HD44780_I2C::setDelay(int cmdDelay, int charDelay) {}
 
-uint8_t PCF8574_HD44780_I2C::keypad (){return 0;}
-uint8_t PCF8574_HD44780_I2C::init_bargraph(uint8_t graphtype){return 0;}
-void PCF8574_HD44780_I2C::draw_horizontal_graph(uint8_t row, uint8_t column, uint8_t len,  uint8_t pixel_col_end){}
-void PCF8574_HD44780_I2C::draw_vertical_graph(uint8_t row, uint8_t column, uint8_t len,  uint8_t pixel_row_end){}
-void PCF8574_HD44780_I2C::setContrast(uint8_t new_val){}
-
+uint8_t PCF8574_HD44780_I2C::keypad() { return 0; }
+uint8_t PCF8574_HD44780_I2C::init_bargraph(uint8_t graphtype) { return 0; }
+void PCF8574_HD44780_I2C::draw_horizontal_graph(uint8_t row, uint8_t column, uint8_t len, uint8_t pixel_col_end) {}
+void PCF8574_HD44780_I2C::draw_vertical_graph(uint8_t row, uint8_t column, uint8_t len, uint8_t pixel_row_end) {}
+void PCF8574_HD44780_I2C::setContrast(uint8_t new_val) {}

--- a/PCF8574_HD44780_I2C/PCF8574_HD44780_I2C.cpp
+++ b/PCF8574_HD44780_I2C/PCF8574_HD44780_I2C.cpp
@@ -31,14 +31,16 @@ based on code from:
 // can't assume that its in that state when a sketch starts (and the
 // LiquidCrystal constructor is called).
 
-PCF8574_HD44780_I2C::PCF8574_HD44780_I2C(uint8_t lcd_Addr, uint8_t lcd_cols, uint8_t lcd_rows) {
+PCF8574_HD44780_I2C::PCF8574_HD44780_I2C(uint8_t lcd_Addr, uint8_t lcd_cols, uint8_t lcd_rows) 
+{
 	_Addr = lcd_Addr;
 	_cols = lcd_cols;
 	_rows = lcd_rows;
 	_backlightval = LCD_NOBACKLIGHT;
 }
 
-void PCF8574_HD44780_I2C::init() {
+void PCF8574_HD44780_I2C::init() 
+{
 	init_priv();
 }
 

--- a/PCF8574_HD44780_I2C/PCF8574_HD44780_I2C.h
+++ b/PCF8574_HD44780_I2C/PCF8574_HD44780_I2C.h
@@ -111,6 +111,8 @@ public:
     void printstr(const char[]);
 
     int status();
+    uint8_t col();
+    uint8_t row();
     char getChar();
     void getString(char *buffer, size_t len);
     void getCursor(uint8_t &col, uint8_t &row);

--- a/PCF8574_HD44780_I2C/PCF8574_HD44780_I2C.h
+++ b/PCF8574_HD44780_I2C/PCF8574_HD44780_I2C.h
@@ -7,7 +7,6 @@ based on code from:
 - Mario H.
 **********************************/
 
-
 #ifndef PCF8574_HD44780_I2C_h
 #define PCF8574_HD44780_I2C_h
 
@@ -16,21 +15,21 @@ based on code from:
 #include <Wire.h>
 
 // Expander I/O port
-#define P7	7
-#define P6	6
-#define P5	5
-#define P4	4
-#define P3	3
-#define P2	2
-#define P1	1
-#define P0	0
+#define P7 7
+#define P6 6
+#define P5 5
+#define P4 4
+#define P3 3
+#define P2 2
+#define P1 1
+#define P0 0
 
 // LCD signals
-#define LCD_BACKLIGHT _BV(P3)		// Led ON
-#define LCD_NOBACKLIGHT 0x00		// Led OFF
-#define En _BV(P2)					// Enable
-#define Rw _BV(P1)					// Read/Write
-#define Rs _BV(P0)					// Register select
+#define LCD_BACKLIGHT _BV(P3) // Led ON
+#define LCD_NOBACKLIGHT 0x00  // Led OFF
+#define En _BV(P2)            // Enable
+#define Rw _BV(P1)            // Read/Write
+#define Rs _BV(P0)            // Register select
 
 // commands
 #define LCD_CLEARDISPLAY 0x01
@@ -43,108 +42,107 @@ based on code from:
 #define LCD_SETDDRAMADDR 0x80
 
 // flags for display entry mode
-#define LCD_ENTRYLEFT 0x02			// I/D Increment
-#define LCD_ENTRYRIGHT 0x00			// I/D Decrement
-#define LCD_ENTRYSHIFTINCREMENT 0x01// S Accompanies display shift
+#define LCD_ENTRYLEFT 0x02           // I/D Increment
+#define LCD_ENTRYRIGHT 0x00          // I/D Decrement
+#define LCD_ENTRYSHIFTINCREMENT 0x01 // S Accompanies display shift
 #define LCD_ENTRYSHIFTDECREMENT 0x00
 
 // flags for display on/off control
-#define LCD_DISPLAYON 0x04			// D
+#define LCD_DISPLAYON 0x04 // D
 #define LCD_DISPLAYOFF 0x00
-#define LCD_CURSORON 0x02			// C
+#define LCD_CURSORON 0x02 // C
 #define LCD_CURSOROFF 0x00
-#define LCD_BLINKON 0x01			// B
+#define LCD_BLINKON 0x01 // B
 #define LCD_BLINKOFF 0x00
 
 // flags for cursor/display shift
-#define LCD_DISPLAYMOVE 0x08		// S/C Display shift
-#define LCD_CURSORMOVE 0x00			// S/C Cursor move
-#define LCD_MOVERIGHT 0x04			// R/L Shift to the right
-#define LCD_MOVELEFT 0x00			 // R/L Shift to the left
+#define LCD_DISPLAYMOVE 0x08 // S/C Display shift
+#define LCD_CURSORMOVE 0x00  // S/C Cursor move
+#define LCD_MOVERIGHT 0x04   // R/L Shift to the right
+#define LCD_MOVELEFT 0x00    // R/L Shift to the left
 
 // flags for function set
-#define LCD_8BITMODE 0x10			// DL
+#define LCD_8BITMODE 0x10 // DL
 #define LCD_4BITMODE 0x00
-#define LCD_2LINE 0x08				// N
+#define LCD_2LINE 0x08 // N
 #define LCD_1LINE 0x00
-#define LCD_5x10DOTS 0x04			// F
+#define LCD_5x10DOTS 0x04 // F
 #define LCD_5x8DOTS 0x00
 
-
-
-class PCF8574_HD44780_I2C : public Print {
+class PCF8574_HD44780_I2C : public Print
+{
 public:
-  enum {LCD_UP, LCD_DOWN, LCD_LEFT, LCD_RIGHT};
-  PCF8574_HD44780_I2C(uint8_t lcd_Addr,uint8_t lcd_cols,uint8_t lcd_rows);
-  void begin(uint8_t cols, uint8_t rows, uint8_t charsize = LCD_5x8DOTS );
-  void clear();
-  void home();
-  void noDisplay();
-  void display();
-  void noBlink();
-  void blink();
-  void noCursor();
-  void cursor();
-  void scrollDisplayLeft();
-  void scrollDisplayRight();
-  void printLeft();
-  void printRight();
-  void leftToRight();
-  void rightToLeft();
-  void shiftIncrement();
-  void shiftDecrement();
-  void noBacklight();
-  void backlight();
-  void autoscroll();
-  void noAutoscroll();
-  void createChar(uint8_t, uint8_t[]);
-  void setCursor(uint8_t, uint8_t);
-  virtual size_t write(uint8_t);
-  void command(uint8_t);
-  void init();
+    enum  { LCD_UP, LCD_DOWN, LCD_LEFT, LCD_RIGHT };
+    PCF8574_HD44780_I2C(uint8_t lcd_Addr, uint8_t lcd_cols, uint8_t lcd_rows);
+    void begin(uint8_t cols, uint8_t rows, uint8_t charsize = LCD_5x8DOTS);
+    void clear();
+    void home();
+    void noDisplay();
+    void display();
+    void noBlink();
+    void blink();
+    void noCursor();
+    void cursor();
+    void scrollDisplayLeft();
+    void scrollDisplayRight();
+    void printLeft();
+    void printRight();
+    void leftToRight();
+    void rightToLeft();
+    void shiftIncrement();
+    void shiftDecrement();
+    void noBacklight();
+    void backlight();
+    void autoscroll();
+    void noAutoscroll();
+    void createChar(uint8_t, uint8_t[]);
+    void setCursor(uint8_t, uint8_t);
+    virtual size_t write(uint8_t);
+    void command(uint8_t);
+    void init();
 
-////compatibility API function aliases
-void blink_on();						// alias for blink()
-void blink_off();       					// alias for noBlink()
-void cursor_on();      	 					// alias for cursor()
-void cursor_off();      					// alias for noCursor()
-void setBacklight(uint8_t new_val);				// alias for backlight() and nobacklight()
-void load_custom_character(uint8_t char_num, uint8_t *rows);	// alias for createChar()
-void printstr(const char[]);
+    ////compatibility API function aliases
+    void blink_on();                                             // alias for blink()
+    void blink_off();                                            // alias for noBlink()
+    void cursor_on();                                            // alias for cursor()
+    void cursor_off();                                           // alias for noCursor()
+    void setBacklight(uint8_t new_val);                          // alias for backlight() and nobacklight()
+    void load_custom_character(uint8_t char_num, uint8_t *rows); // alias for createChar()
+    void printstr(const char[]);
 
-int status();
-char getChar();
-void getString(char* buffer, size_t len);
-void getCursor(uint8_t &col, uint8_t &row);
-void moveCursor(uint8_t dir, uint8_t step = 1);
+    int status();
+    char getChar();
+    void getString(char *buffer, size_t len);
+    void getCursor(uint8_t &col, uint8_t &row);
+    void moveCursor(uint8_t dir, uint8_t step = 1);
 
-////Unsupported API functions (not implemented in this library)
-void setContrast(uint8_t new_val);
-uint8_t keypad();
-void setDelay(int,int);
-void on();
-void off();
-uint8_t init_bargraph(uint8_t graphtype);
-void draw_horizontal_graph(uint8_t row, uint8_t column, uint8_t len,  uint8_t pixel_col_end);
-void draw_vertical_graph(uint8_t row, uint8_t column, uint8_t len,  uint8_t pixel_col_end);
+    ////Unsupported API functions (not implemented in this library)
+    void setContrast(uint8_t new_val);
+    uint8_t keypad();
+    void setDelay(int, int);
+    void on();
+    void off();
+    uint8_t init_bargraph(uint8_t graphtype);
+    void draw_horizontal_graph(uint8_t row, uint8_t column, uint8_t len, uint8_t pixel_col_end);
+    void draw_vertical_graph(uint8_t row, uint8_t column, uint8_t len, uint8_t pixel_col_end);
 
 private:
-  void init_priv();
-  void send(uint8_t, uint8_t);
-  void write4bits(uint8_t);
-  void expanderWrite(uint8_t);
-  void pulseEnable(uint8_t);
+    void init_priv();
+    void send(uint8_t, uint8_t);
+    void write4bits(uint8_t);
+    void expanderWrite(uint8_t);
+    void pulseEnable(uint8_t);
 
-  int read(uint8_t);
+    int read(uint8_t);
 
-  uint8_t _Addr;
-  uint8_t _displayfunction;
-  uint8_t _displaycontrol;
-  uint8_t _displaymode;
-  uint8_t _numlines;
-  uint8_t _cols;
-  uint8_t _rows;
-  uint8_t _backlightval;
+    uint8_t _Addr;
+    uint8_t _displayfunction;
+    uint8_t _displaycontrol;
+    uint8_t _displaymode;
+    uint8_t _numlines;
+    uint8_t _cols;
+    uint8_t _rows;
+    uint8_t _backlightval;
 };
 
 #endif

--- a/PCF8574_HD44780_I2C/PCF8574_HD44780_I2C.h
+++ b/PCF8574_HD44780_I2C/PCF8574_HD44780_I2C.h
@@ -71,8 +71,10 @@ based on code from:
 #define LCD_5x8DOTS 0x00
 
 
+
 class PCF8574_HD44780_I2C : public Print {
 public:
+  enum {LCD_UP, LCD_DOWN, LCD_LEFT, LCD_RIGHT};
   PCF8574_HD44780_I2C(uint8_t lcd_Addr,uint8_t lcd_cols,uint8_t lcd_rows);
   void begin(uint8_t cols, uint8_t rows, uint8_t charsize = LCD_5x8DOTS );
   void clear();
@@ -110,10 +112,11 @@ void setBacklight(uint8_t new_val);				// alias for backlight() and nobacklight(
 void load_custom_character(uint8_t char_num, uint8_t *rows);	// alias for createChar()
 void printstr(const char[]);
 
-inline int status() {
-  return read(0);
-}
-void getCursor(uint8_t &col, uint8_t &row) ;
+int status();
+char getChar();
+void getString(char* buffer, size_t len);
+void getCursor(uint8_t &col, uint8_t &row);
+void moveCursor(uint8_t dir, uint8_t step = 1);
 
 ////Unsupported API functions (not implemented in this library)
 void setContrast(uint8_t new_val);

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ PCF8574+HD44780 LCD I2C Arduino Library
 
 ### Changelog
 2.3.1
-- Added moveCursor() function
+- Added moveCursor(), row() and col() functions
 - Added readChar() and readString() functions
 
 2.3.0 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ PCF8574+HD44780 LCD I2C Arduino Library
 - Original Library Ver 2.0 (not working on this breakoutboard) http://hmario.home.xs4all.nl/arduino/LiquidCrystal_I2C/
 
 ### Changelog
+2.3.1
+- Added moveCursor() function
+- Added readChar() and readString() functions
+
 2.3.0 
 - Added public getCursor() and status() and private read() methods.
 - Added new example GetCursor.ino


### PR DESCRIPTION
Ci sono molte differenze nei file sorgenti, ma solo perché ho usato "clang format" per uniformare la formattazione del codice (spazi, tabulazioni etc etc).